### PR TITLE
Add charging cable sensor and API resilience dependencies

### DIFF
--- a/custom_components/lucidmotors/binary_sensor.py
+++ b/custom_components/lucidmotors/binary_sensor.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 import logging
 
-from lucidmotors import Vehicle, WalkawayState, DoorState, HvacPower
+from lucidmotors import Vehicle, WalkawayState, DoorState, HvacPower, ChargeState
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -110,6 +110,15 @@ SENSOR_TYPES: dict[str, LucidBinarySensorEntityDescription] = {
         translation_key="hvac_power",
         icon="mdi:hvac",
         is_on_fn=lambda vehicle: vehicle.state.hvac.power != HvacPower.HVAC_OFF,
+    ),
+    "charging_cable": LucidBinarySensorEntityDescription(
+        key="charge_state",
+        key_path=["state", "charging"],
+        translation_key="charging_cable",
+        icon="mdi:ev-plug-tesla",
+        device_class=BinarySensorDeviceClass.PLUG,
+        is_on_fn=lambda vehicle: vehicle.state.charging.charge_state
+        != ChargeState.Value('CHARGE_STATE_NOT_CONNECTED'),
     ),
 }
 

--- a/custom_components/lucidmotors/manifest.json
+++ b/custom_components/lucidmotors/manifest.json
@@ -10,9 +10,11 @@
   "issue_tracker": "https://github.com/borski/ha-lucidmotors/issues",
   "requirements": [
     "lucidmotors==1.3.0",
-    "markdownify==0.11.6"
+    "markdownify==0.11.6",
+    "async-lru==2.0.4",
+    "tenacity==8.2.3"
   ],
   "ssdp": [],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "zeroconf": []
 }


### PR DESCRIPTION
New binary_sensor for Charging Cable: Adds a sensor to report if the vehicle is plugged in. This uses the charge_state attribute from the API.

Updated Dependencies - Adds tenacity and async-lru to manifest.json. These are required for an upcoming resilience update in the underlying python-lucidmotors library, which will hopefully solve the RESOURCE_EXHAUSTED errors.