### PR TITLE
Add missing translation for the charging cable binary sensor

### DIFF
--- a/custom_components/lucidmotors/strings.json
+++ b/custom_components/lucidmotors/strings.json
@@ -166,6 +166,9 @@
       },
       "hvac_power": {
         "name": "HVAC power"
+      },
+      "charging_cable": {
+        "name": "Charging cable"
       }
     },
     "button": {

--- a/custom_components/lucidmotors/translations/en.json
+++ b/custom_components/lucidmotors/translations/en.json
@@ -50,6 +50,9 @@
             },
             "walkaway_lock": {
                 "name": "Walkaway lock"
+            },
+            "charging_cable": {
+                "name": "Charging cable"
             }
         },
         "button": {


### PR DESCRIPTION
The `charging_cable` binary sensor added in #31 sets `translation_key="charging_cable"`, but no matching entry was ever added to `strings.json` or `translations/en.json`.

Home Assistant therefore has no name to give the entity and falls back to the device name, so it shows up as just the vehicle name with an object id derived from the device class — `binary_sensor.<vehicle>_plug` — rather than anything recognisable.

This adds the missing name to both files. Two lines each, no behaviour change.
