### PR TITLE
Read the persisted AC current limit, not the active session one

### DIFF
--- a/custom_components/lucidmotors/number.py
+++ b/custom_components/lucidmotors/number.py
@@ -12,7 +12,7 @@ from homeassistant.components.number import NumberEntity, NumberEntityDescriptio
 from homeassistant.const import PERCENTAGE
 from homeassistant.const import UnitOfElectricCurrent
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -58,16 +58,18 @@ NUMBER_TYPES: tuple[LucidNumberEntityDescription, ...] = (
         ),
     ),
     LucidNumberEntityDescription(
-        key="active_session_ac_current_limit",
+        key="energy_ac_current_limit",
         key_path=["state", "charging"],
         translation_key="ac_charge_current_limit",
         icon="mdi:current-ac",
         native_step=1,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        native_min_value=10.0,
+        # 8 A is the lowest current IEC 61851 permits for AC charging; the
+        # upper bound is the Air's 19.2 kW onboard charger at 240 V.
+        native_min_value=8.0,
         native_max_value=80.0,
-        native_value_fn=lambda vehicle: round(
-            vehicle.state.charging.active_session_ac_current_limit
+        native_value_fn=lambda vehicle: (
+            vehicle.state.charging.energy_ac_current_limit or 80
         ),
         set_native_value_fn=lambda api, vehicle, value: api.set_ac_current_limit(
             vehicle, round(value)
@@ -103,6 +105,11 @@ class LucidNumber(LucidBaseEntity, NumberEntity):
     entity_description: LucidNumberEntityDescription
     _attr_has_entity_name: bool = True
     _is_on: bool
+    # Holds the value we just sent to the car until the coordinator confirms
+    # it with a fresh vehicle poll. Without this, async_write_ha_state()
+    # immediately re-reads native_value_fn from the stale cache and the
+    # slider snaps back to the old value.
+    _optimistic_value: float | None = None
 
     def __init__(
         self,
@@ -116,9 +123,17 @@ class LucidNumber(LucidBaseEntity, NumberEntity):
         self.api = coordinator.api
         self._attr_unique_id = f"{vehicle.config.vin}-{description.key}"
 
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Drop the optimistic value once fresh vehicle data arrives."""
+        self._optimistic_value = None
+        super()._handle_coordinator_update()
+
     @property
     def native_value(self) -> float:
-        """Return native value."""
+        """Return native value, preferring a pending optimistic write."""
+        if self._optimistic_value is not None:
+            return self._optimistic_value
         return self.entity_description.native_value_fn(self.vehicle)
 
     async def async_set_native_value(self, value: float) -> None:
@@ -135,6 +150,8 @@ class LucidNumber(LucidBaseEntity, NumberEntity):
             await self.entity_description.set_native_value_fn(
                 self.api, self.vehicle, value
             )
+            # Show the new value immediately instead of the stale cached one.
+            self._optimistic_value = value
             self.async_write_ha_state()
         except APIError as ex:
             raise HomeAssistantError(ex) from ex


### PR DESCRIPTION
`ChargingState` carries two AC current fields, and the library documents them separately in `LucidAPI.get_ac_current_settings()`:

| field | meaning |
| --- | --- |
| `active_session_ac_current_limit` | limit for the active charging session |
| `energy_ac_current_limit` | the persisted user setting |

The number entity added in #38 reads `active_session_ac_current_limit`, which is `0` whenever no session is in progress — so for a car that is simply parked, the slider sits at 0. This reads `energy_ac_current_limit` instead, which is what the setter writes to and what the app displays.

Two smaller fixes to the same entity:

- `native_min_value` from 10 A to 8 A, the minimum AC charging current IEC 61851 permits.
- Hold the value just written until the next coordinator poll confirms it. Previously `async_write_ha_state()` re-read the stale cached vehicle state and the slider snapped back to its old position for the rest of the polling interval.

**One thing worth flagging:** this changes the entity's `unique_id`, so existing installs get a new entity and the old one is orphaned. #38 isn't in a tagged release yet, so this seemed better than carrying the wrong field forward — but happy to add a migration instead if you'd prefer.
