### PR TITLE
Add TCU connectivity sensors and key fob battery status

### DIFF
--- a/custom_components/lucidmotors/binary_sensor.py
+++ b/custom_components/lucidmotors/binary_sensor.py
@@ -6,7 +6,18 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 import logging
 
-from lucidmotors import Vehicle, WalkawayState, DoorState, HvacPower, ChargeState
+from lucidmotors import (
+    Vehicle,
+    WalkawayState,
+    DoorState,
+    HvacPower,
+    ChargeState,
+    InternetStatus,
+)
+
+# KeyfobBatteryStatus is not re-exported from the lucidmotors package in
+# 1.4.1, so it has to come from the generated module directly.
+from lucidmotors.gen.vehicle_state_service_pb2 import KeyfobBatteryStatus
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -119,6 +130,33 @@ SENSOR_TYPES: dict[str, LucidBinarySensorEntityDescription] = {
         device_class=BinarySensorDeviceClass.PLUG,
         is_on_fn=lambda vehicle: vehicle.state.charging.charge_state
         != ChargeState.Value('CHARGE_STATE_NOT_CONNECTED'),
+    ),
+    "keyfob_battery_low": LucidBinarySensorEntityDescription(
+        key="keyfob_battery_status",
+        key_path=["state", "body"],
+        translation_key="keyfob_battery_low",
+        icon="mdi:key-wireless",
+        device_class=BinarySensorDeviceClass.BATTERY,
+        is_on_fn=lambda vehicle: vehicle.state.body.keyfob_battery_status
+        == KeyfobBatteryStatus.KEYFOB_BATTERY_STATUS_LOW,
+    ),
+    "lte_connected": LucidBinarySensorEntityDescription(
+        key="lte_status",
+        key_path=["state", "tcu_internet"],
+        translation_key="lte_connected",
+        icon="mdi:signal",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        is_on_fn=lambda vehicle: vehicle.state.tcu_internet.lte_status
+        == InternetStatus.INTERNET_CONNECTED,
+    ),
+    "wifi_connected": LucidBinarySensorEntityDescription(
+        key="wifi_status",
+        key_path=["state", "tcu_internet"],
+        translation_key="wifi_connected",
+        icon="mdi:wifi",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        is_on_fn=lambda vehicle: vehicle.state.tcu_internet.wifi_status
+        == InternetStatus.INTERNET_CONNECTED,
     ),
 }
 

--- a/custom_components/lucidmotors/sensor.py
+++ b/custom_components/lucidmotors/sensor.py
@@ -19,6 +19,7 @@ from lucidmotors import (
     DriveMode,
     GearPosition,
     TcuDownloadStatus,
+    LteType,
     enum_to_str,
 )
 from lucidmotors.const import TIRE_PRESSURE_MAX, CHARGE_SESSION_TIME_MAX
@@ -32,6 +33,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     UnitOfEnergy,
     UnitOfLength,
     UnitOfPower,
@@ -41,6 +43,7 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util.unit_conversion import DistanceConverter
@@ -329,6 +332,42 @@ SENSOR_TYPES: list[LucidSensorEntityDescription] = [
         icon="mdi:cloud-download",
         device_class=SensorDeviceClass.ENUM,
         value=lambda value, _: enum_to_str(TcuDownloadStatus, value),
+    ),
+    LucidSensorEntityDescription(
+        key="lte_type",
+        key_path=["state", "tcu_internet"],
+        translation_key="lte_type",
+        icon="mdi:signal-4g",
+        device_class=SensorDeviceClass.ENUM,
+        # lucidmotors 1.4.1 only defines 3G and 4G; anything else (including
+        # LTE_TYPE_UNKNOWN) is reported as unknown rather than invented.
+        options=["3G", "4G"],
+        value=lambda value, _: {
+            LteType.LTE_TYPE_3G: "3G",
+            LteType.LTE_TYPE_4G: "4G",
+        }.get(value),
+    ),
+    LucidSensorEntityDescription(
+        key="lte_rssi",
+        key_path=["state", "tcu_internet"],
+        translation_key="lte_signal_strength",
+        icon="mdi:signal",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        # The TCU reports 0 when it has no LTE signal at all.
+        value=lambda value, _: None if value == 0 else value,
+    ),
+    LucidSensorEntityDescription(
+        key="wifi_rssi",
+        key_path=["state", "tcu_internet"],
+        translation_key="wifi_signal_strength",
+        icon="mdi:wifi",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        # As above: 0 means "not associated", not "0 dBm".
+        value=lambda value, _: None if value == 0 else value,
     ),
 ]
 

--- a/custom_components/lucidmotors/strings.json
+++ b/custom_components/lucidmotors/strings.json
@@ -134,6 +134,15 @@
       },
       "update_download_status": {
         "name": "Update download status"
+      },
+      "lte_type": {
+        "name": "LTE type"
+      },
+      "lte_signal_strength": {
+        "name": "LTE signal strength"
+      },
+      "wifi_signal_strength": {
+        "name": "Wi-Fi signal strength"
       }
     },
     "binary_sensor": {
@@ -166,6 +175,15 @@
       },
       "hvac_power": {
         "name": "HVAC power"
+      },
+      "keyfob_battery_low": {
+        "name": "Key fob battery low"
+      },
+      "lte_connected": {
+        "name": "LTE connected"
+      },
+      "wifi_connected": {
+        "name": "Wi-Fi connected"
       }
     },
     "button": {

--- a/custom_components/lucidmotors/translations/en.json
+++ b/custom_components/lucidmotors/translations/en.json
@@ -50,6 +50,15 @@
             },
             "walkaway_lock": {
                 "name": "Walkaway lock"
+            },
+            "keyfob_battery_low": {
+                "name": "Key fob battery low"
+            },
+            "lte_connected": {
+                "name": "LTE connected"
+            },
+            "wifi_connected": {
+                "name": "Wi-Fi connected"
             }
         },
         "button": {
@@ -226,6 +235,15 @@
             },
             "update_download_status": {
               "name": "Update download status"
+            },
+            "lte_type": {
+                "name": "LTE type"
+            },
+            "lte_signal_strength": {
+                "name": "LTE signal strength"
+            },
+            "wifi_signal_strength": {
+                "name": "Wi-Fi signal strength"
             }
         },
         "select": {


### PR DESCRIPTION
`VehicleState.tcu_internet` and `BodyState.keyfob_battery_status` are already populated by the API but weren't surfaced anywhere.

**Sensors**

| entity | field |
| --- | --- |
| LTE type | `tcu_internet.lte_type` |
| LTE signal strength | `tcu_internet.lte_rssi` |
| Wi-Fi signal strength | `tcu_internet.wifi_rssi` |

**Binary sensors**

| entity | field |
| --- | --- |
| Key fob battery low | `body.keyfob_battery_status` |
| LTE connected | `tcu_internet.lte_status` |
| Wi-Fi connected | `tcu_internet.wifi_status` |

Both RSSI sensors map a reported `0` to `None` and are marked diagnostic. The TCU uses 0 to mean "no signal", and charting that as 0 dBm would be wrong by about 90 dB.

"Wi-Fi connected" makes a useful automation trigger for anyone who wants different behaviour when the car is on their home network.

`LteType` only defines 3G and 4G in lucidmotors 1.4.1, so `options` lists exactly those and anything else reads as unknown rather than inventing a value.

**Note:** `KeyfobBatteryStatus` is imported from `lucidmotors.gen` because the `lucidmotors` package doesn't re-export it in 1.4.1. Happy to send a patch to the library adding the export and switch to a public import if you'd prefer that.
