### PR TITLE
Add charge port power, scheduled charge state and cable lock

### DIFF
--- a/custom_components/lucidmotors/binary_sensor.py
+++ b/custom_components/lucidmotors/binary_sensor.py
@@ -6,7 +6,14 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 import logging
 
-from lucidmotors import Vehicle, WalkawayState, DoorState, HvacPower, ChargeState
+from lucidmotors import (
+    Vehicle,
+    WalkawayState,
+    DoorState,
+    HvacPower,
+    ChargeState,
+    LockState,
+)
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -119,6 +126,19 @@ SENSOR_TYPES: dict[str, LucidBinarySensorEntityDescription] = {
         device_class=BinarySensorDeviceClass.PLUG,
         is_on_fn=lambda vehicle: vehicle.state.charging.charge_state
         != ChargeState.Value('CHARGE_STATE_NOT_CONNECTED'),
+    ),
+    "cable_lock": LucidBinarySensorEntityDescription(
+        key="cable_lock",
+        key_path=["state", "charging"],
+        translation_key="charge_cable_lock",
+        icon="mdi:lock-outline",
+        device_class=BinarySensorDeviceClass.LOCK,
+        # BinarySensorDeviceClass.LOCK is on == unlocked. LOCK_STATE_UNKNOWN
+        # is reported as unknown rather than being lumped in with unlocked.
+        is_on_fn=lambda vehicle: {
+            LockState.LOCK_STATE_LOCKED: False,
+            LockState.LOCK_STATE_UNLOCKED: True,
+        }.get(vehicle.state.charging.cable_lock),
     ),
 }
 

--- a/custom_components/lucidmotors/sensor.py
+++ b/custom_components/lucidmotors/sensor.py
@@ -19,6 +19,7 @@ from lucidmotors import (
     DriveMode,
     GearPosition,
     TcuDownloadStatus,
+    ScheduledChargeState,
     enum_to_str,
 )
 from lucidmotors.const import TIRE_PRESSURE_MAX, CHARGE_SESSION_TIME_MAX
@@ -32,6 +33,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
+    UnitOfElectricCurrent,
     UnitOfEnergy,
     UnitOfLength,
     UnitOfPower,
@@ -329,6 +331,43 @@ SENSOR_TYPES: list[LucidSensorEntityDescription] = [
         icon="mdi:cloud-download",
         device_class=SensorDeviceClass.ENUM,
         value=lambda value, _: enum_to_str(TcuDownloadStatus, value),
+    ),
+    LucidSensorEntityDescription(
+        key="active_session_ac_current_limit",
+        key_path=["state", "charging"],
+        translation_key="active_session_ac_current_limit",
+        icon="mdi:current-ac",
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        suggested_display_precision=0,
+        # 0 means there is no active session, not a 0 A limit.
+        value=lambda value, _: None if value == 0 else value,
+    ),
+    LucidSensorEntityDescription(
+        key="port_power",
+        key_path=["state", "charging"],
+        translation_key="charge_port_power",
+        icon="mdi:ev-plug-type2",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        suggested_display_precision=1,
+        # Sub-milliwatt readings are floating point noise, not charging.
+        value=lambda value, _: None if value < 0.001 else value,
+    ),
+    LucidSensorEntityDescription(
+        key="scheduled_charge",
+        key_path=["state", "charging"],
+        translation_key="scheduled_charge_state",
+        icon="mdi:calendar-clock",
+        device_class=SensorDeviceClass.ENUM,
+        options=["idle", "scheduled", "charging_soon"],
+        value=lambda value, _: {
+            ScheduledChargeState.SCHEDULED_CHARGE_STATE_IDLE: "idle",
+            ScheduledChargeState.SCHEDULED_CHARGE_STATE_SCHEDULED_TO_CHARGE: "scheduled",
+            ScheduledChargeState.SCHEDULED_CHARGE_STATE_REQUEST_TO_CHARGE: "charging_soon",
+        }.get(value),
     ),
 ]
 

--- a/custom_components/lucidmotors/strings.json
+++ b/custom_components/lucidmotors/strings.json
@@ -134,6 +134,20 @@
       },
       "update_download_status": {
         "name": "Update download status"
+      },
+      "active_session_ac_current_limit": {
+        "name": "AC charge current (session)"
+      },
+      "charge_port_power": {
+        "name": "Charge port power"
+      },
+      "scheduled_charge_state": {
+        "name": "Scheduled charge state",
+        "state": {
+          "idle": "Idle",
+          "scheduled": "Scheduled",
+          "charging_soon": "Charging soon"
+        }
       }
     },
     "binary_sensor": {
@@ -166,6 +180,9 @@
       },
       "hvac_power": {
         "name": "HVAC power"
+      },
+      "charge_cable_lock": {
+        "name": "Charge cable lock"
       }
     },
     "button": {

--- a/custom_components/lucidmotors/translations/en.json
+++ b/custom_components/lucidmotors/translations/en.json
@@ -50,6 +50,9 @@
             },
             "walkaway_lock": {
                 "name": "Walkaway lock"
+            },
+            "charge_cable_lock": {
+                "name": "Charge cable lock"
             }
         },
         "button": {
@@ -226,6 +229,20 @@
             },
             "update_download_status": {
               "name": "Update download status"
+            },
+            "active_session_ac_current_limit": {
+                "name": "AC charge current (session)"
+            },
+            "charge_port_power": {
+                "name": "Charge port power"
+            },
+            "scheduled_charge_state": {
+                "name": "Scheduled charge state",
+                "state": {
+                    "idle": "Idle",
+                    "scheduled": "Scheduled",
+                    "charging_soon": "Charging soon"
+                }
             }
         },
         "select": {


### PR DESCRIPTION
Four charging fields the API already returns but nothing exposed.

| entity | field |
| --- | --- |
| Charge port power | `charging.port_power` |
| AC charge current (session) | `charging.active_session_ac_current_limit` |
| Scheduled charge state | `charging.scheduled_charge` |
| Charge cable lock (binary sensor) | `charging.cable_lock` |

`charge_port_power` is the one worth discussing, because it overlaps with the existing `power_usage` sensor without replacing it. `power_usage` derives power from the difference in `battery.kwhr` between two polls, which is the only option while driving. `port_power` is what the car itself reports at the inlet, so it's both more accurate and more responsive while charging. Keeping both seemed right: one covers discharge, the other charge.

The session current limit maps `0` to `None`, since 0 means "no active session" rather than a 0 A limit.

The cable lock uses `BinarySensorDeviceClass.LOCK`, where on means unlocked. `LOCK_STATE_UNKNOWN` maps to `None` so an unknown state isn't silently presented as unlocked.
