### PR TITLE
Add battery preconditioning, unavailable range, keep climate and fault sensors

### DIFF
--- a/custom_components/lucidmotors/binary_sensor.py
+++ b/custom_components/lucidmotors/binary_sensor.py
@@ -6,7 +6,14 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 import logging
 
-from lucidmotors import Vehicle, WalkawayState, DoorState, HvacPower, ChargeState
+from lucidmotors import (
+    Vehicle,
+    WalkawayState,
+    DoorState,
+    HvacPower,
+    ChargeState,
+    DefrostState,
+)
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -119,6 +126,14 @@ SENSOR_TYPES: dict[str, LucidBinarySensorEntityDescription] = {
         device_class=BinarySensorDeviceClass.PLUG,
         is_on_fn=lambda vehicle: vehicle.state.charging.charge_state
         != ChargeState.Value('CHARGE_STATE_NOT_CONNECTED'),
+    ),
+    "defrost": LucidBinarySensorEntityDescription(
+        key="defrost",
+        key_path=["state", "hvac"],
+        translation_key="defrost",
+        icon="mdi:car-defrost-front",
+        is_on_fn=lambda vehicle: vehicle.state.hvac.defrost
+        == DefrostState.DEFROST_ON,
     ),
 }
 

--- a/custom_components/lucidmotors/sensor.py
+++ b/custom_components/lucidmotors/sensor.py
@@ -23,6 +23,12 @@ from lucidmotors import (
 )
 from lucidmotors.const import TIRE_PRESSURE_MAX, CHARGE_SESSION_TIME_MAX
 
+# Neither enum is re-exported from the lucidmotors package in 1.4.1.
+from lucidmotors.gen.vehicle_state_service_pb2 import (
+    KeepClimateStatus,
+    MpbFaultStatus,
+)
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -41,6 +47,7 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util.unit_conversion import DistanceConverter
@@ -329,6 +336,71 @@ SENSOR_TYPES: list[LucidSensorEntityDescription] = [
         icon="mdi:cloud-download",
         device_class=SensorDeviceClass.ENUM,
         value=lambda value, _: enum_to_str(TcuDownloadStatus, value),
+    ),
+    LucidSensorEntityDescription(
+        key="preconditioning_time_remaining",
+        key_path=["state", "battery"],
+        translation_key="preconditioning_time_remaining",
+        icon="mdi:battery-clock",
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        suggested_display_precision=0,
+        # 0xFFFF is the sentinel the pack uses for "not preconditioning".
+        value=lambda value, _: None if value in (0, 65535) else value,
+    ),
+    LucidSensorEntityDescription(
+        key="unavailable_range",
+        key_path=["state", "battery"],
+        translation_key="unavailable_range",
+        icon="mdi:map-marker-remove",
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        suggested_display_precision=0,
+        value=lambda value, _: None if value == 0.0 else value,
+    ),
+    LucidSensorEntityDescription(
+        key="keep_climate_status",
+        key_path=["state", "hvac"],
+        translation_key="keep_climate_status",
+        icon="mdi:paw",
+        device_class=SensorDeviceClass.ENUM,
+        options=["inactive", "enabled", "canceled", "pet_mode"],
+        value=lambda value, _: {
+            KeepClimateStatus.KEEP_CLIMATE_STATUS_INACTIVE: "inactive",
+            KeepClimateStatus.KEEP_CLIMATE_STATUS_ENABLED: "enabled",
+            KeepClimateStatus.KEEP_CLIMATE_STATUS_CANCELED: "canceled",
+            KeepClimateStatus.KEEP_CLIMATE_STATUS_PET_MODE_ON: "pet_mode",
+        }.get(value),
+    ),
+    LucidSensorEntityDescription(
+        key="mpb_fault_status",
+        key_path=["state", "fault_state"],
+        translation_key="motor_fault_status",
+        icon="mdi:engine",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.ENUM,
+        options=[
+            "normal",
+            "warning",
+            "critical",
+            "warning_protection",
+            "critical_protection",
+            "critical_hardware",
+        ],
+        # MPB is the Motor Power Bridge, i.e. the inverter. HAPS variants are
+        # protection-system sub-faults and HW_FLT is a hardware fault.
+        # UNKNOWN / RESERVED / INVALID map to None so the entity reads as
+        # unknown rather than showing a state nobody can act on.
+        value=lambda value, _: {
+            MpbFaultStatus.MPB_FAULT_STATUS_NORMAL: "normal",
+            MpbFaultStatus.MPB_FAULT_STATUS_WARNING: "warning",
+            MpbFaultStatus.MPB_FAULT_STATUS_CRITICAL: "critical",
+            MpbFaultStatus.MPB_FAULT_STATUS_WARNING_HAPS: "warning_protection",
+            MpbFaultStatus.MPB_FAULT_STATUS_CRITICAL_HAPS: "critical_protection",
+            MpbFaultStatus.MPB_FAULT_STATUS_CRITICAL_HW_FLT: "critical_hardware",
+        }.get(value),
     ),
 ]
 

--- a/custom_components/lucidmotors/strings.json
+++ b/custom_components/lucidmotors/strings.json
@@ -134,6 +134,32 @@
       },
       "update_download_status": {
         "name": "Update download status"
+      },
+      "preconditioning_time_remaining": {
+        "name": "Battery preconditioning time remaining"
+      },
+      "unavailable_range": {
+        "name": "Unavailable range"
+      },
+      "keep_climate_status": {
+        "name": "Keep climate status",
+        "state": {
+          "inactive": "Inactive",
+          "enabled": "Enabled",
+          "canceled": "Canceled",
+          "pet_mode": "Pet mode"
+        }
+      },
+      "motor_fault_status": {
+        "name": "Motor fault status",
+        "state": {
+          "normal": "Normal",
+          "warning": "Warning",
+          "critical": "Critical fault",
+          "warning_protection": "Warning (protection system)",
+          "critical_protection": "Critical (protection system)",
+          "critical_hardware": "Critical hardware fault"
+        }
       }
     },
     "binary_sensor": {
@@ -166,6 +192,9 @@
       },
       "hvac_power": {
         "name": "HVAC power"
+      },
+      "defrost": {
+        "name": "Defrost"
       }
     },
     "button": {

--- a/custom_components/lucidmotors/translations/en.json
+++ b/custom_components/lucidmotors/translations/en.json
@@ -50,6 +50,9 @@
             },
             "walkaway_lock": {
                 "name": "Walkaway lock"
+            },
+            "defrost": {
+                "name": "Defrost"
             }
         },
         "button": {
@@ -226,6 +229,32 @@
             },
             "update_download_status": {
               "name": "Update download status"
+            },
+            "preconditioning_time_remaining": {
+                "name": "Battery preconditioning time remaining"
+            },
+            "unavailable_range": {
+                "name": "Unavailable range"
+            },
+            "keep_climate_status": {
+                "name": "Keep climate status",
+                "state": {
+                    "inactive": "Inactive",
+                    "enabled": "Enabled",
+                    "canceled": "Canceled",
+                    "pet_mode": "Pet mode"
+                }
+            },
+            "motor_fault_status": {
+                "name": "Motor fault status",
+                "state": {
+                    "normal": "Normal",
+                    "warning": "Warning",
+                    "critical": "Critical fault",
+                    "warning_protection": "Warning (protection system)",
+                    "critical_protection": "Critical (protection system)",
+                    "critical_hardware": "Critical hardware fault"
+                }
             }
         },
         "select": {


### PR DESCRIPTION
Five more fields the API returns but nothing exposed.

| entity | field |
| --- | --- |
| Battery preconditioning time remaining | `battery.preconditioning_time_remaining` |
| Unavailable range | `battery.unavailable_range` |
| Keep climate status | `hvac.keep_climate_status` |
| Motor fault status | `fault_state.mpb_fault_status` |
| Defrost (binary sensor) | `hvac.defrost` |

`preconditioning_time_remaining` uses `0xFFFF` as its "not preconditioning" sentinel; both that and 0 map to `None`.

Motor fault status is marked diagnostic. MPB is the Motor Power Bridge — the inverter. The HAPS variants are protection-system sub-faults and `HW_FLT` is a hardware fault. `UNKNOWN`, `RESERVED` and `INVALID` map to `None` rather than being listed as options, since none of them mean anything actionable to a user.

**On the defrost binary sensor:** it overlaps with the defrost preset already on the climate entity. It's here because a binary sensor is considerably easier to use as an automation trigger or condition than a climate preset attribute. Entirely happy to drop it from this PR if you'd rather not carry both representations.

**Note:** `KeepClimateStatus` and `MpbFaultStatus` are imported from `lucidmotors.gen` because the `lucidmotors` package doesn't re-export them in 1.4.1 — same situation as the key fob enum in the connectivity PR.
