### PR TITLE
Add GPS heading, elevation and coordinate sensors

### DIFF
--- a/custom_components/lucidmotors/sensor.py
+++ b/custom_components/lucidmotors/sensor.py
@@ -31,6 +31,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    DEGREE,
     PERCENTAGE,
     UnitOfEnergy,
     UnitOfLength,
@@ -329,6 +330,48 @@ SENSOR_TYPES: list[LucidSensorEntityDescription] = [
         icon="mdi:cloud-download",
         device_class=SensorDeviceClass.ENUM,
         value=lambda value, _: enum_to_str(TcuDownloadStatus, value),
+    ),
+    LucidSensorEntityDescription(
+        key="heading_precise",
+        key_path=["state", "gps"],
+        translation_key="gps_heading",
+        icon="mdi:compass",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=DEGREE,
+        suggested_display_precision=0,
+    ),
+    LucidSensorEntityDescription(
+        key="elevation",
+        key_path=["state", "gps"],
+        translation_key="gps_elevation",
+        icon="mdi:elevation-rise",
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfLength.METERS,
+        suggested_display_precision=0,
+        # Reported in centimetres; see the PR description for how this was
+        # established, the protobuf carries no unit.
+        value=lambda value, _: round(value / 100, 1),
+    ),
+    LucidSensorEntityDescription(
+        key="latitude",
+        key_path=["state", "gps", "location"],
+        translation_key="gps_latitude",
+        icon="mdi:latitude",
+        entity_registry_enabled_default=False,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=DEGREE,
+        suggested_display_precision=6,
+    ),
+    LucidSensorEntityDescription(
+        key="longitude",
+        key_path=["state", "gps", "location"],
+        translation_key="gps_longitude",
+        icon="mdi:longitude",
+        entity_registry_enabled_default=False,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=DEGREE,
+        suggested_display_precision=6,
     ),
 ]
 

--- a/custom_components/lucidmotors/strings.json
+++ b/custom_components/lucidmotors/strings.json
@@ -134,6 +134,18 @@
       },
       "update_download_status": {
         "name": "Update download status"
+      },
+      "gps_heading": {
+        "name": "GPS heading"
+      },
+      "gps_elevation": {
+        "name": "GPS elevation"
+      },
+      "gps_latitude": {
+        "name": "GPS latitude"
+      },
+      "gps_longitude": {
+        "name": "GPS longitude"
       }
     },
     "binary_sensor": {

--- a/custom_components/lucidmotors/translations/en.json
+++ b/custom_components/lucidmotors/translations/en.json
@@ -226,6 +226,18 @@
             },
             "update_download_status": {
               "name": "Update download status"
+            },
+            "gps_heading": {
+                "name": "GPS heading"
+            },
+            "gps_elevation": {
+                "name": "GPS elevation"
+            },
+            "gps_latitude": {
+                "name": "GPS latitude"
+            },
+            "gps_longitude": {
+                "name": "GPS longitude"
             }
         },
         "select": {


### PR DESCRIPTION
`VehicleState.gps` carries `heading_precise` and `elevation`, neither of which was exposed. The device tracker gives position but not bearing or altitude, so these are additive rather than duplicative.

**Elevation is divided by 100.** The protobuf declares it as a bare `int` with no unit, but the raw values are consistently 100x the true altitude in metres for known locations, so it's centimetres. Calling that out explicitly because it's an empirical finding rather than something the schema states — if you'd rather not ship a guessed unit, I'm happy to expose the raw value instead and let people scale it themselves.

Latitude and longitude are also added, but with `entity_registry_enabled_default=False`. They duplicate what the device tracker already provides and they put precise location into the recorder, so they're opt-in: useful for templates and dashboards that want a plain numeric coordinate, and off by default for everyone else.
