### PR TITLE
Add passive (walkaway) lock and unlock switches

### DIFF
--- a/custom_components/lucidmotors/__init__.py
+++ b/custom_components/lucidmotors/__init__.py
@@ -75,6 +75,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass, api, entry.data["username"], entry.data["password"]
     )
     await coordinator.async_config_entry_first_refresh()
+    await coordinator.async_init_preferences(api.vehicles)
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 

--- a/custom_components/lucidmotors/coordinator.py
+++ b/custom_components/lucidmotors/coordinator.py
@@ -5,8 +5,23 @@ from __future__ import annotations
 import asyncio
 from datetime import timedelta, datetime
 import logging
+from typing import Any
 
-from lucidmotors import APIError, LucidAPI, Vehicle, StatusCode, PowerState
+import grpc
+
+from lucidmotors import (
+    APIError,
+    LucidAPI,
+    Vehicle,
+    StatusCode,
+    PowerState,
+    Model,
+    enum_to_str,
+)
+from lucidmotors.gen import (
+    user_preferences_service_pb2,
+    user_preferences_service_pb2_grpc,
+)
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -53,6 +68,11 @@ class LucidDataUpdateCoordinator(DataUpdateCoordinator[None]):
         self.password = password
         self._vehicles = {}
         self._expected_updates = {}
+        # Model preferences are stored per model, not per vehicle: the API
+        # keys them by model name, so two Airs on one account share a record.
+        self._model_prefs: dict[str, Any] = {}
+        self._prefs_commit_id: dict[str, int] = {}
+        self._user_prefs_stub: Any = None
 
     async def _async_update_data(self) -> None:
         """Fetch new data from API."""
@@ -172,3 +192,179 @@ class LucidDataUpdateCoordinator(DataUpdateCoordinator[None]):
         expiration_time = datetime.now() + timedelta(seconds=FAST_UPDATE_TIMEOUT)
         self._expected_updates[vin][path] = expiration_time
         await self.async_request_refresh()
+
+    # ------------------------------------------------------------------
+    # Vehicle model preferences (passive lock / unlock)
+    #
+    # These live on UserPreferencesService rather than VehicleStateService,
+    # which the lucidmotors client does not wrap, so the stub is built here
+    # against the client's channel.
+    # ------------------------------------------------------------------
+
+    async def async_init_preferences(self, vehicles: list[Vehicle]) -> None:
+        """Build the preferences stub and prime the cache for each vehicle."""
+        # TODO: lucidmotors exposes no public accessor for its channel. If a
+        # UserPreferencesService wrapper lands in the library this should
+        # switch to it.
+        self._user_prefs_stub = (
+            user_preferences_service_pb2_grpc.UserPreferencesServiceStub(
+                self.api._channel
+            )
+        )
+        for vehicle in vehicles:
+            await self._async_fetch_model_preferences(vehicle)
+
+    def _model_name(self, vehicle: Vehicle) -> str:
+        """Return the model name the preferences API keys records by."""
+        return enum_to_str(Model, vehicle.config.model)
+
+    async def _async_fetch_model_preferences(self, vehicle: Vehicle) -> None:
+        """Fetch and cache the preferences record for a vehicle's model."""
+        if self._user_prefs_stub is None:
+            return
+
+        model = self._model_name(vehicle)
+        request = user_preferences_service_pb2.GetUserModelPreferencesRequest(
+            model=model
+        )
+
+        try:
+            response = await self._user_prefs_stub.GetUserModelPreferences(request)
+        except grpc.aio.AioRpcError as err:
+            if err.code() is grpc.StatusCode.NOT_FOUND:
+                _LOGGER.info(
+                    "No model preferences exist for %s yet, creating them", model
+                )
+                await self._async_create_model_preferences(model)
+            else:
+                _LOGGER.warning(
+                    "Could not read model preferences for %s: %s", model, err
+                )
+            return
+
+        self._model_prefs[model] = response.preferences
+        self._prefs_commit_id[model] = response.commit_id
+
+    async def _async_create_model_preferences(self, model: str) -> None:
+        """Create a defaults record for a model, then cache it."""
+        try:
+            await self._user_prefs_stub.CreateUserModelPreferences(
+                user_preferences_service_pb2.CreateUserModelPreferencesRequest(
+                    preferences=user_preferences_service_pb2.VehicleModelPreferences(
+                        model=model,
+                    ),
+                )
+            )
+            response = await self._user_prefs_stub.GetUserModelPreferences(
+                user_preferences_service_pb2.GetUserModelPreferencesRequest(
+                    model=model
+                )
+            )
+        except grpc.aio.AioRpcError as err:
+            _LOGGER.warning(
+                "Could not create model preferences for %s: %s", model, err
+            )
+            return
+
+        self._model_prefs[model] = response.preferences
+        self._prefs_commit_id[model] = response.commit_id
+
+    async def _async_set_model_preference(
+        self, vehicle: Vehicle, field: str, value: bool
+    ) -> None:
+        """Write one preference field and confirm the server took it.
+
+        Two things worth knowing about this endpoint.
+
+        First, the wire format cannot express "false". passive_lock and
+        passive_unlock are plain proto3 bools with no field presence, and
+        SetUserModelPreferencesRequest carries no field mask, so setting
+        either to False serialises to nothing and the field is simply absent
+        from the request. In practice the server appears to treat the record
+        as a replacement and does store False - it reads back as False on
+        subsequent Get calls - but that is observed behaviour rather than
+        anything the schema guarantees. The read-back below checks it rather
+        than assuming it.
+
+        Second, and more importantly, storing the preference is not the same
+        as the car honouring it. This is an account-level preference; the
+        vehicle reports its own walkaway state separately and has been seen
+        to keep reporting WALKAWAY_ACTIVE with the preference set to False.
+        There is no VehicleStateService RPC for passive entry in lucidmotors
+        1.4.1, so this is the only control the API offers. The switch entity
+        compares the two and warns when they disagree.
+        """
+        if self._user_prefs_stub is None:
+            raise APIError("Vehicle preferences service is not available")
+
+        model = self._model_name(vehicle)
+
+        # Re-read first: if the app or another client has written since our
+        # last fetch, our commit_id is stale and the server rejects the write.
+        await self._async_fetch_model_preferences(vehicle)
+        if model not in self._model_prefs:
+            raise APIError(f"Could not read current preferences for {model}")
+
+        new_prefs = user_preferences_service_pb2.VehicleModelPreferences()
+        new_prefs.CopyFrom(self._model_prefs[model])
+        setattr(new_prefs, field, value)
+
+        _LOGGER.debug(
+            "Writing %s=%s for %s at prev_commit_id=%d; fields on the wire: %s",
+            field,
+            value,
+            model,
+            self._prefs_commit_id.get(model, 0),
+            [f.name for f, _ in new_prefs.ListFields()],
+        )
+
+        try:
+            await self._user_prefs_stub.SetUserModelPreferences(
+                user_preferences_service_pb2.SetUserModelPreferencesRequest(
+                    preferences=new_prefs,
+                    prev_commit_id=self._prefs_commit_id.get(model, 0),
+                )
+            )
+        except grpc.aio.AioRpcError as err:
+            raise APIError(f"Could not write {field} for {model}: {err}") from err
+
+        # Confirm against the server rather than trusting the write.
+        await self._async_fetch_model_preferences(vehicle)
+        applied = getattr(self._model_prefs[model], field)
+        _LOGGER.debug(
+            "Read back %s=%s for %s at commit_id=%d (wanted %s)",
+            field,
+            applied,
+            model,
+            self._prefs_commit_id.get(model, 0),
+            value,
+        )
+        if applied != value:
+            raise APIError(
+                f"The vehicle did not accept {field}={value}; "
+                f"it still reports {applied}"
+            )
+
+    def _preference(self, vin: str, field: str) -> bool | None:
+        """Return a cached preference for a vehicle, or None if unknown."""
+        vehicle = self.get_vehicle(vin)
+        if vehicle is None:
+            return None
+        prefs = self._model_prefs.get(self._model_name(vehicle))
+        return getattr(prefs, field) if prefs is not None else None
+
+    def get_passive_lock(self, vin: str) -> bool | None:
+        """Return whether passive (walkaway) lock is enabled."""
+        return self._preference(vin, "passive_lock")
+
+    def get_passive_unlock(self, vin: str) -> bool | None:
+        """Return whether passive (walkaway) unlock is enabled."""
+        return self._preference(vin, "passive_unlock")
+
+    async def async_set_passive_lock(self, vehicle: Vehicle, enabled: bool) -> None:
+        """Enable or disable passive (walkaway) lock."""
+        await self._async_set_model_preference(vehicle, "passive_lock", enabled)
+
+    async def async_set_passive_unlock(self, vehicle: Vehicle, enabled: bool) -> None:
+        """Enable or disable passive (walkaway) unlock."""
+        await self._async_set_model_preference(vehicle, "passive_unlock", enabled)

--- a/custom_components/lucidmotors/strings.json
+++ b/custom_components/lucidmotors/strings.json
@@ -190,6 +190,12 @@
       },
       "battery_preconditioning": {
         "name": "Battery preconditioning"
+      },
+      "passive_lock": {
+        "name": "Passive lock (walkaway)"
+      },
+      "passive_unlock": {
+        "name": "Passive unlock (walkaway)"
       }
     },
     "light": {

--- a/custom_components/lucidmotors/switch.py
+++ b/custom_components/lucidmotors/switch.py
@@ -14,6 +14,7 @@ from lucidmotors import (
     DefrostState,
     ChargeState,
     BatteryPreconStatus,
+    WalkawayState,
 )
 
 from homeassistant.components.switch import (
@@ -24,6 +25,7 @@ from homeassistant.components.switch import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import LucidBaseEntity
@@ -74,22 +76,80 @@ SWITCH_TYPES: tuple[LucidSwitchEntityDescription, ...] = (
 )
 
 
+@dataclass(frozen=True)
+class LucidPreferenceSwitchEntityDescriptionMixin:
+    """Mixin to describe a Lucid switch backed by a model preference."""
+
+    get_fn: Callable[[LucidDataUpdateCoordinator, str], bool | None]
+    set_fn: Callable[
+        [LucidDataUpdateCoordinator, Vehicle, bool], Coroutine[None, None, None]
+    ]
+    # Reader for the car's own reported state of the same feature, or None
+    # where the vehicle reports nothing comparable. These switches write an
+    # account-level preference and the vehicle does not necessarily follow
+    # it, so where the car does report something we can notice the two
+    # disagreeing and say so.
+    #
+    # No default: SwitchEntityDescription.key has none and is ordered after
+    # the mixin's fields, so a default here is a TypeError at import.
+    vehicle_state_fn: Callable[[Vehicle], bool | None] | None
+
+
+@dataclass(frozen=True)
+class LucidPreferenceSwitchEntityDescription(
+    SwitchEntityDescription, LucidPreferenceSwitchEntityDescriptionMixin
+):
+    """Describes a preference-backed Lucid switch."""
+
+
+PREFERENCE_SWITCH_TYPES: tuple[LucidPreferenceSwitchEntityDescription, ...] = (
+    LucidPreferenceSwitchEntityDescription(
+        key="passive_lock",
+        translation_key="passive_lock",
+        icon="mdi:car-door-lock",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.CONFIG,
+        vehicle_state_fn=lambda vehicle: vehicle.state.body.walkaway_lock
+        == WalkawayState.WALKAWAY_ACTIVE,
+        get_fn=lambda coordinator, vin: coordinator.get_passive_lock(vin),
+        set_fn=lambda coordinator, vehicle, on: coordinator.async_set_passive_lock(
+            vehicle, on
+        ),
+    ),
+    LucidPreferenceSwitchEntityDescription(
+        key="passive_unlock",
+        translation_key="passive_unlock",
+        icon="mdi:car-key",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.CONFIG,
+        # The car reports no passive-unlock state of its own to compare with.
+        vehicle_state_fn=None,
+        get_fn=lambda coordinator, vin: coordinator.get_passive_unlock(vin),
+        set_fn=lambda coordinator, vehicle, on: coordinator.async_set_passive_unlock(
+            vehicle, on
+        ),
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Lucid sensors from config entry."""
+    """Set up the Lucid switches from config entry."""
     coordinator: LucidDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities: list[LucidSwitch] = []
+    entities: list[LucidSwitch | LucidPreferenceSwitch] = []
 
     for vehicle in coordinator.api.vehicles:
         entities.extend(
-            [
-                LucidSwitch(coordinator, vehicle, description)
-                for description in SWITCH_TYPES
-            ]
+            LucidSwitch(coordinator, vehicle, description)
+            for description in SWITCH_TYPES
+        )
+        entities.extend(
+            LucidPreferenceSwitch(coordinator, vehicle, description)
+            for description in PREFERENCE_SWITCH_TYPES
         )
 
     async_add_entities(entities)
@@ -162,3 +222,109 @@ class LucidSwitch(LucidBaseEntity, SwitchEntity):
     def is_on(self) -> bool:
         """Get the current state of the switch."""
         return self._is_on
+
+
+class LucidPreferenceSwitch(LucidBaseEntity, SwitchEntity):
+    """A Lucid switch backed by an account-level vehicle model preference.
+
+    These write to UserPreferencesService, which stores a preference against
+    the account and model. That is a different thing from the vehicle's own
+    state, and the car is not obliged to follow it: as of lucidmotors 1.4.1
+    there is no VehicleStateService RPC for passive entry at all, so this
+    preference is the only knob the API exposes.
+
+    In testing the server accepted and returned passive_lock=False while the
+    car continued to report WALKAWAY_ACTIVE and kept unlocking on approach.
+    Whether the setting reaches the vehicle is therefore up to Lucid, not to
+    this integration. Where the car reports a comparable state we compare the
+    two and log a warning when they disagree, so a preference that has not
+    been honoured is visible rather than silent.
+    """
+
+    entity_description: LucidPreferenceSwitchEntityDescription
+    _attr_has_entity_name: bool = True
+
+    def __init__(
+        self,
+        coordinator: LucidDataUpdateCoordinator,
+        vehicle: Vehicle,
+        description: LucidPreferenceSwitchEntityDescription,
+    ) -> None:
+        """Initialize the preference switch."""
+        super().__init__(coordinator, vehicle)
+        self.entity_description = description
+        self._attr_unique_id = f"{vehicle.config.vin}-{description.key}"
+        self._attr_is_on = False
+        # Preferences are read once at setup, separately from the vehicle
+        # poll, so an entity can exist before its value is known.
+        self._preference_known = False
+        self._warned_divergence = False
+        self._read_preference()
+
+    @property
+    def available(self) -> bool:
+        """Report unavailable until the preferences record has been read.
+
+        CoordinatorEntity implements available as a property, so setting
+        _attr_available here would have no effect.
+        """
+        return super().available and self._preference_known
+
+    def _read_preference(self) -> None:
+        """Refresh local state from the coordinator's preference cache."""
+        value = self.entity_description.get_fn(self.coordinator, self.vin)
+        _LOGGER.debug(
+            "Preference switch '%s' of %s reads as %s",
+            self.entity_description.key,
+            self.vehicle.config.nickname,
+            value,
+        )
+        self._preference_known = value is not None
+        if value is not None:
+            self._attr_is_on = value
+            self._check_vehicle_agrees(value)
+
+    def _check_vehicle_agrees(self, preference: bool) -> None:
+        """Warn once if the car's reported state contradicts the preference."""
+        reader = self.entity_description.vehicle_state_fn
+        if reader is None:
+            return
+        reported = reader(self.vehicle)
+        if reported is None or reported == preference:
+            self._warned_divergence = False
+            return
+        if not self._warned_divergence:
+            self._warned_divergence = True
+            _LOGGER.warning(
+                "%s is set to %s for %s, but the car reports it as %s. The "
+                "preference was stored, so this is the vehicle not applying "
+                "it rather than a failed write",
+                self.entity_description.key,
+                preference,
+                self.vehicle.config.nickname,
+                reported,
+            )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._read_preference()
+        super()._handle_coordinator_update()
+
+    async def _async_set(self, enabled: bool) -> None:
+        try:
+            await self.entity_description.set_fn(
+                self.coordinator, self.vehicle, enabled
+            )
+        except APIError as ex:
+            raise HomeAssistantError(ex) from ex
+        self._read_preference()
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable the preference."""
+        await self._async_set(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable the preference."""
+        await self._async_set(False)

--- a/custom_components/lucidmotors/translations/en.json
+++ b/custom_components/lucidmotors/translations/en.json
@@ -275,6 +275,12 @@
             },
             "battery_preconditioning": {
                 "name": "Battery preconditioning"
+            },
+            "passive_lock": {
+                "name": "Passive lock (walkaway)"
+            },
+            "passive_unlock": {
+                "name": "Passive unlock (walkaway)"
             }
         }
     }


### PR DESCRIPTION
Refs #36.

The Lucid app's walkaway lock and unlock settings live on `UserPreferencesService.GetUserModelPreferences` / `SetUserModelPreferences`, which the `lucidmotors` client doesn't wrap. This builds a stub for that service against the client's existing channel, caches the record, and exposes two switches.

Preference records are keyed by model rather than by VIN, so the cache is keyed the same way and two vehicles of the same model on one account share a record. The `commit_id` is re-read immediately before every write, since a change made in the app invalidates the one we hold.

## Please read this before merging: it does not currently change the car's behaviour

Writing the preference works. The server accepts it and returns the new value on every subsequent read. What it does **not** do is reach the vehicle. With `passive_lock` stored as `False` and reading back as `False`, my Air went on reporting:

```
body { walkaway_lock: WALKAWAY_ACTIVE }
```

and went on behaving that way — walked up with the key, it unlocked; walked away, it relocked. `WalkawayState` has a `WALKAWAY_DISABLE` value that the car simply never enters.

I went looking for a vehicle-side control and there isn't one. The complete `VehicleStateService` method list in lucidmotors 1.4.1:

```
AllWindowControl, ApplySoftwareUpdate, CancelScheduledUpdate, ChargeControl,
ControlChargePort, DischargeControl, DoorControl, DoorLocksControl, FrontCargoControl,
GetDocumentInfo, GetOtaVersionHistory, GetVehicleState, HonkHorn, HvacDefrostControl,
InitiatePhoneAsKey, KeylessDrivingAction, LightsControl, PanicAlarmAction,
ReadStatusPhoneAsKey, RearCargoControl, SeatClimateControl, SecurityAlarmControl,
SetACCurrLimit, SetBatteryPrecon, SetCabinTemperature, SetChargeLimit,
SetCreatureComfortMode, SetDischargeSoeLimit, SetMaxAC, SetScheduledOta,
SteeringWheelHeater, UpdateChargingSchedule, WakeupVehicle, WelcomeControl
```

Nothing for passive entry or walkaway. So this account preference is the entire surface the API offers — there's no second endpoint being missed.

My reading is that this is a propagation gap on Lucid's side: the preference is stored against the account but never pushed to the vehicle. If that's right, it isn't something this integration can fix, and it also wouldn't need any change here once Lucid connects the two.

I'm proposing it anyway because the entities accurately reflect a real account setting the app itself exposes, and if propagation ever starts working they light up with no code change. But it is entirely your call whether that's worth carrying in the meantime, and I won't be offended if the answer is no.

To keep the limitation visible rather than silent:

- Both switches are `EntityCategory.CONFIG`, so they present as settings rather than as controls that act on the car.
- Every write is read back and compared, and a mismatch raises.
- `passive_lock` is compared against the car's own reported walkaway state on each poll, and a disagreement logs a warning that names the vehicle as the thing that hasn't applied it:

```
WARNING passive_lock is set to False for Lucid AIR, but the car reports it as True.
        The preference was stored, so this is the vehicle not applying it rather
        than a failed write
```

## Two smaller things for review

- This reaches `api._channel`, which is private. There's a `TODO` in the code — if a `UserPreferencesService` wrapper ever lands in the library this should switch to it.
- Setting either bool to `False` serialises to nothing: they're plain proto3 bools with no field presence, and `SetUserModelPreferencesRequest` has no field mask, so the field is simply absent from the request. The server appears to treat the record as a replacement and does store `False`, but that's observed behaviour rather than anything the schema guarantees — which is why the read-back check is there rather than assuming it.

If anyone has captured what the app sends when you toggle walkaway off in its own UI, I'd love to see it — it would settle whether the app uses this endpoint at all.
