### PR TITLE
Name the tracker and update entities, and force tracker updates

### DIFF
--- a/custom_components/lucidmotors/device_tracker.py
+++ b/custom_components/lucidmotors/device_tracker.py
@@ -37,7 +37,7 @@ async def async_setup_entry(
 class LucidTrackerEntity(LucidBaseEntity, TrackerEntity):
     """Tracker for Lucid vehicles."""
 
-    _attr_force_update: bool = False
+    _attr_force_update: bool = True
     _attr_icon: str = "mdi:car"
 
     def __init__(
@@ -47,7 +47,7 @@ class LucidTrackerEntity(LucidBaseEntity, TrackerEntity):
         super().__init__(coordinator, vehicle)
 
         self._attr_unique_id = self.vehicle.config.vin
-        self._attr_name = None
+        self._attr_translation_key = "location"
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/lucidmotors/strings.json
+++ b/custom_components/lucidmotors/strings.json
@@ -240,6 +240,16 @@
       "ac_charge_current_limit": {
         "name": "AC charge current limit"
       }
+    },
+    "device_tracker": {
+      "location": {
+        "name": "Location"
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Software update"
+      }
     }
   }
 }

--- a/custom_components/lucidmotors/translations/en.json
+++ b/custom_components/lucidmotors/translations/en.json
@@ -276,6 +276,16 @@
             "battery_preconditioning": {
                 "name": "Battery preconditioning"
             }
+        },
+        "device_tracker": {
+            "location": {
+                "name": "Location"
+            }
+        },
+        "update": {
+            "software_update": {
+                "name": "Software update"
+            }
         }
     }
 }

--- a/custom_components/lucidmotors/update.py
+++ b/custom_components/lucidmotors/update.py
@@ -55,7 +55,7 @@ class LucidUpdateEntity(LucidBaseEntity, UpdateEntity):
         super().__init__(coordinator, vehicle)
 
         self._attr_unique_id = f"{vehicle.config.vin}-update"
-        self._attr_name = None
+        self._attr_translation_key = "software_update"
         self.api = coordinator.api
 
     @property


### PR DESCRIPTION
Two independent changes, both of which I'm happy to drop. They're isolated in their own PR precisely so they don't hold up anything else.

## Naming

`device_tracker` and `update` both set `_attr_name = None`, so each inherits the bare device name. The result is `device_tracker.lucid_air` and `update.lucid_air` sitting alongside a set of otherwise properly named entities. Giving them translation keys makes them read as "Location" and "Software update".

**This renames the entities for existing installs, which is a breaking change.** Entity ids are unaffected; only the friendly names change. Still, it's a visible change for every current user, so it may well not be worth it.

## force_update on the tracker

The tracker only writes state when a value changes, so a stationary car produces no history at all and map cards can show gaps after a restart. Setting `force_update = True` writes on every poll instead.

The cost is recorder volume, and it isn't small — worth being upfront that this is a real tradeoff rather than a free improvement. Happy to drop this half specifically, or put it behind a config option rather than making it the default.
