### PR TITLE
Fix implausible battery percentage readings, and show tenths

### DIFF
--- a/custom_components/lucidmotors/sensor.py
+++ b/custom_components/lucidmotors/sensor.py
@@ -51,6 +51,26 @@ from .coordinator import LucidDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+# The battery module sometimes reports 255 for its percentage signals: the 0xFF
+# "signal invalid" sentinel arriving as a literal value instead of being
+# filtered out before it reaches us. Nothing above this cutoff is a real
+# percentage, so drop it rather than record a spike.
+MAX_PLAUSIBLE_PERCENTAGE = 110.0
+
+
+def _plausible_percentage(value: float, name: str) -> float | None:
+    """Return value, or None when it is too large to be a real percentage."""
+    if value > MAX_PLAUSIBLE_PERCENTAGE:
+        _LOGGER.warning(
+            "Ignoring implausible %s of %s%%: above the %s%% cutoff, so the "
+            "sensor reports unknown until the next valid reading",
+            name,
+            value,
+            MAX_PLAUSIBLE_PERCENTAGE,
+        )
+        return None
+    return value
+
 
 @dataclass(frozen=True)
 class LucidSensorEntityDescription(SensorEntityDescription):
@@ -69,6 +89,7 @@ SENSOR_TYPES: list[LucidSensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
         native_unit_of_measurement=PERCENTAGE,
+        value=lambda value, _: _plausible_percentage(value, "battery charge"),
     ),
     LucidSensorEntityDescription(
         key="kwhr",
@@ -311,6 +332,7 @@ SENSOR_TYPES: list[LucidSensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
         suggested_display_precision=1,
+        value=lambda value, _: _plausible_percentage(value, "battery health level"),
     ),
     LucidSensorEntityDescription(
         key="speed",

--- a/custom_components/lucidmotors/sensor.py
+++ b/custom_components/lucidmotors/sensor.py
@@ -87,7 +87,7 @@ SENSOR_TYPES: list[LucidSensorEntityDescription] = [
         translation_key="remaining_battery_percent",
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=0,
+        suggested_display_precision=1,
         native_unit_of_measurement=PERCENTAGE,
         value=lambda value, _: _plausible_percentage(value, "battery charge"),
     ),


### PR DESCRIPTION
Two small changes to the battery percentage sensor, in separate commits so
either can be dropped independently.

---

## 1. Implausible readings (255%)

`charge_percent` intermittently comes back as `255`.

`BatteryState.charge_percent` is a plain `double` with no field presence, so the
0xFF "signal invalid" sentinel from the battery module arrives as a literal
value with nothing to distinguish it from a real reading. It goes straight into
the entity, and the result is a battery sensor showing **255%**.

The display glitch is the small part. The bad sample is written to the recorder,
so it stays in history and it skews the long-term statistics for that hour —
`max` for the hour becomes 255, and the mean is dragged with it. That damage
outlives the poll it came from.

Readings above 110% are now discarded rather than stored. The sensor reports
`unknown` for that poll and recovers on the next one, which is how the existing
sentinel handling in this file already behaves — `TIRE_PRESSURE_MAX`,
`CHARGE_SESSION_TIME_MAX` and the `0xFFFF` preconditioning sentinel all map to
`None` the same way. A one-poll gap is far cheaper than a permanent spike.

The drop is logged at `WARNING` rather than done silently, so anyone who hits
this can see it in the log instead of wondering where the gap came from:

```
WARNING Ignoring implausible battery charge of 255.0%: above the 110.0% cutoff,
        so the sensor reports unknown until the next valid reading
```

110 rather than 100 leaves room for a car that legitimately reports slightly
over 100 after a full charge, while still being nowhere near 255.

## 2. Display precision

The sensor sets `suggested_display_precision=0`, but the API reports
`charge_percent` in exact tenths. Sampled from a debug log while charging:

```
54.8  54.9  55.0  55.1  55.2 ... 57.8      # 32 distinct values, all clean tenths
```

Rounding to whole numbers throws away resolution the car is already providing,
and it makes slow changes look like nothing is happening: at 0.1% per poll the
displayed value sits still for ten polls and then jumps by 1. Raised to `1`,
matching `battery_health_level`, the other percentage sensor read from
`BatteryState`.

This changes the suggested precision only, so anyone who has set an explicit
display precision on the entity keeps theirs.

---

### Two things to flag

**`battery_health_level` also gets the 110% filter.** It's the other
`PERCENTAGE` sensor read from the same `BatteryState` message, so it's exposed
to the same failure mode. I haven't personally caught it at 255 — only
`charge_percent` — so if you'd rather not fix something unobserved, say so and
I'll drop that hunk.

**No lower bound.** Only the observed failure mode is handled; a negative
percentage would still pass through. Easy to add if you'd prefer the check be
symmetric, but I didn't want to guard against something I haven't seen.
