### PR TITLE
Show the precision the battery and charging sensors actually have

### DIFF
--- a/custom_components/lucidmotors/sensor.py
+++ b/custom_components/lucidmotors/sensor.py
@@ -97,7 +97,7 @@ SENSOR_TYPES: list[LucidSensorEntityDescription] = [
         translation_key="remaining_battery_power",
         device_class=SensorDeviceClass.ENERGY_STORAGE,
         state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=0,
+        suggested_display_precision=2,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
     ),
     LucidSensorEntityDescription(
@@ -106,7 +106,7 @@ SENSOR_TYPES: list[LucidSensorEntityDescription] = [
         translation_key="battery_capacity",
         device_class=SensorDeviceClass.ENERGY_STORAGE,
         state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=0,
+        suggested_display_precision=1,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
     ),
     LucidSensorEntityDescription(
@@ -116,7 +116,7 @@ SENSOR_TYPES: list[LucidSensorEntityDescription] = [
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         icon="mdi:battery-charging",
-        suggested_display_precision=0,
+        suggested_display_precision=2,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
     ),
     LucidSensorEntityDescription(
@@ -126,7 +126,7 @@ SENSOR_TYPES: list[LucidSensorEntityDescription] = [
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL_INCREASING,
         icon="mdi:map-marker-distance",
-        suggested_display_precision=0,
+        suggested_display_precision=1,
         native_unit_of_measurement=UnitOfLength.MILES,
     ),
     LucidSensorEntityDescription(
@@ -144,7 +144,7 @@ SENSOR_TYPES: list[LucidSensorEntityDescription] = [
         translation_key="charging_rate_distance",
         device_class=SensorDeviceClass.SPEED,
         state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=0,
+        suggested_display_precision=1,
         native_unit_of_measurement=UnitOfSpeed.MILES_PER_HOUR,
     ),
     LucidSensorEntityDescription(


### PR DESCRIPTION
Five sensors round away resolution the API is already handing us.

I logged 626 full vehicle state dumps across one complete charge session on an
Air and compared what each numeric field actually contains against the precision
its sensor displays.

| sensor | shows | data has | distinct values shown / real |
| --- | --- | --- | --- |
| `remaining_battery_power` | 0 dp | **2 dp** | 11 / **210** |
| `charge_session_power` | 0 dp | **2 dp** | 10 / **210** |
| `charge_session_range` | 0 dp | **1 dp** | 47 / **210** |
| `charging_rate_range_estimate` | 0 dp | **1 dp** | 4 / **37** |
| `battery_capacity` | 0 dp | **1 dp** | reads `101.7`, displays `102` |

### Why it's worth changing

The visible symptom is a sensor that sits still while the car is plainly doing
something. Over that session:

```
remaining_battery_power   at 0 dp: held one displayed value for up to 66 consecutive polls
                          at 2 dp: never more than 3
```

Sixty-six polls of a battery visibly charging, then a jump of a whole kWh.

**`remaining_battery_power` is not redundant with the charge percentage.** I
checked whether it's just `capacity x percent` restated, and it isn't:

```
pct=37.6  ->  kwhr 38.19, 38.24, 38.28     three distinct kWh readings at one percentage
pct=37.7  ->  kwhr 38.33, 38.37
```

93 of the 94 distinct percentages observed mapped to two or three distinct kWh
values, so this sensor resolves finer than `remaining_battery_percent` does. At
0 dp we throw away precisely the part that makes it more useful than the
percentage.

`charging_rate_range_estimate` is the one that made me laugh — it reads
`charge_rate_mph_precise` and rounds it to whole mph. It moved between 40.5 and
44.3 during the session and displayed four distinct values.

### Scope

Display precision only. No entity ids, unique ids, units or stored values
change, and anyone who has set an explicit display precision on one of these
entities keeps theirs.

I deliberately left some things alone:

- **Tire pressures** look like they lose a digit in bar (~0.025 bar steps shown
  at 0.1), but `_calculate_precision_from_ratio` shifts the precision on the
  bar→psi conversion, and in psi at 0 dp the granularity is already finer than
  the bar setting implies. Changing it would gain almost nothing and would add a
  pointless decimal for metric users.
- **Latitude/longitude** showed fewer digits than their precision allows, but
  the car was parked for the whole window, so that's not evidence of anything.
- **`battery_health_level`, `elevation`, cell temps, `port_power`,
  `session_minutes_remaining`, `odometer`, the RSSI sensors** all already match
  their data.

Numbers above are from one car over one session, so the exact quantum could
differ on other trims — but all five are cases of visible digits being discarded,
not of inventing precision that isn't there.
